### PR TITLE
Remove needless deref & borrow

### DIFF
--- a/.github/workflows/assemble.yml
+++ b/.github/workflows/assemble.yml
@@ -49,7 +49,7 @@ jobs:
           cargo fmt -- --check
 
       - run: |
-          cargo clippy -- --no-deps -D warnings
+          make cargo-clippy
 
       - run: |
           cargo test

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,10 @@ swagger-ui: ## docs :
 	./scripts/swagger-ui.sh
 
 cargo-clippy: ## lint :
-	cargo clippy -- --no-deps -D warnings
+	cargo clippy -- \
+	    --no-deps \
+	    --allow clippy::derive_partial_eq_without_eq \
+	    --deny warnings
 
 cargo-fmt: ## format :
 	cargo fmt

--- a/libs/gesha-core/src/conversions/v3_0/to_rust_type/post_processor/resolve_ref.rs
+++ b/libs/gesha-core/src/conversions/v3_0/to_rust_type/post_processor/resolve_ref.rs
@@ -80,7 +80,7 @@ impl RefResolver<'_> {
         let is_nullable = self.is_nullable(shape)?;
         let mut data_type = match shape {
             TypeShape::Vec { type_shape, .. } => {
-                DataType::Vec(Box::new(self.type_shape_to_data_type(&*type_shape)?))
+                DataType::Vec(Box::new(self.type_shape_to_data_type(type_shape)?))
             }
             TypeShape::Ref { object, .. } => {
                 let type_name = match String::from(object.clone()) {

--- a/scripts/test-examples.sh
+++ b/scripts/test-examples.sh
@@ -4,8 +4,14 @@ set -xue
 
 main () {
   cd ./examples/v3.0
-  cargo fmt
-  cargo clippy -- --no-deps -D warnings
+
+  cargo fmt -- --check
+
+  cargo clippy -- \
+    --no-deps \
+    --allow clippy::derive_partial_eq_without_eq \
+    --deny warnings
+
   cargo test
 }
 


### PR DESCRIPTION
```
error: deref on an immutable reference
  --> libs/gesha-core/src/conversions/v3_0/to_rust_type/post_processor/resolve_ref.rs:83:69
   |
83 |                 DataType::Vec(Box::new(self.type_shape_to_data_type(&*type_shape)?))
   |                                                                     ^^^^^^^^^^^^
   |
   = note: `-D clippy::borrow-deref-ref` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#borrow_deref_ref
help: if you would like to reborrow, try removing `&*`
   |
83 |                 DataType::Vec(Box::new(self.type_shape_to_data_type(type_shape)?))
   |                                                                     ~~~~~~~~~~
help: if you would like to deref, try using `&**`
   |
83 |                 DataType::Vec(Box::new(self.type_shape_to_data_type(&**type_shape)?))
   |                                                                     ~~~~~~~~~~~~~
```
