### PR TITLE
Modify root Cargo.toml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      day: "friday"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,11 @@
 members = [
     "apps/handcraft",
     "apps/gesha",
+    "libs/gesha-core",
+    "libs/openapi-types",
+    "libs/handcraft/handcraft-models",
+    "libs/handcraft/handcraft-server",
+    "libs/handcraft/handcraft-server-derive",
 ]
 exclude = [
     "examples/v3.0",


### PR DESCRIPTION
dependabot seems to watch only workspace members, not their dependencies.

related issue?

- https://github.com/dependabot/dependabot-core/issues/1207